### PR TITLE
クイズアプリを修正r2

### DIFF
--- a/assets/JS04.css
+++ b/assets/JS04.css
@@ -1,0 +1,5 @@
+
+.btn {
+  display: block;
+  /* width: 10em; */
+}

--- a/assets/JS04.js
+++ b/assets/JS04.js
@@ -1,0 +1,235 @@
+'use strict';
+
+const output = document.getElementById('output');
+let count = 0;
+let correctAnswerCount = 0;
+let selectAnswer = '';
+let janre = [];
+let difficulty = [];
+let question = [];
+let type = [];
+let correct_answer = [];
+let incorrect_answers = [];
+
+
+//最初のページを作成
+function displayTopPage() {
+  const h = document.createElement('h1');
+  h.textContent = 'ようこそ'
+  output.appendChild(h);
+
+  const hr1 = document.createElement('hr');
+  output.appendChild(hr1);
+
+  const p = document.createElement('p');
+  p.textContent = '以下のボタンをクリック';
+  output.appendChild(p);
+
+  const hr2 = document.createElement('hr');
+  output.appendChild(hr2);
+
+  const clickbtn = document.createElement('input');
+  clickbtn.type = 'button';
+  clickbtn.value = '開始';
+  output.appendChild(clickbtn);
+
+  clickbtn.addEventListener('click', function() {
+    output.textContent = '';
+    function finishQuizContent() {
+      return new Promise((resolve) => {
+        resolve(quizContent);
+      })
+    }
+
+    function finishDisplayStayPage() {
+      return new Promise((resolve) => {
+        resolve(displayStayPage);
+      })
+    }
+    //「待機中」ページを出力し、fetchでのデータ読み込みが終了したらクイズ画面を出力
+    Promise.all([
+      finishDisplayStayPage(),
+      finishQuizContent()
+    ]).then(function(){
+      output.textContent = '';
+      console.log('add');
+      add();
+    })
+  } )
+
+}
+displayTopPage();
+
+function add() {
+  if (count < 10) {
+    displayQuiz(janre[count], difficulty[count], question[count], type[count], correct_answer[count], incorrect_answers[count]);
+    console.log(incorrect_answers[count]);
+    }else{
+      displayResult();
+    }
+}
+
+function displayStayPage() {
+  console.log('displayStayPage');
+  const h = document.createElement('h1');
+  h.textContent = '取得中'
+  output.appendChild(h);
+
+  const hr1 = document.createElement('hr');
+  output.appendChild(hr1);
+
+  const p = document.createElement('p');
+  p.textContent = '少々お待ちください。';
+  output.appendChild(p);
+
+  const hr2 = document.createElement('hr');
+  output.appendChild(hr2);
+}
+
+//クイズを取り出す
+function quizContent() {
+  fetch('https://opentdb.com/api.php?amount=10').then(function  (response) {
+    return response.json();
+  }).then(function(json) {
+      return json.results;
+  }).then(function(results) {
+    for (let i = 0; i< results.length; i++) {
+      janre[i] = results[i].category;
+      difficulty[i] = results[i].difficulty;
+      question[i] = results[i].question;
+      type[i] = results[i].type;
+      correct_answer[i] = results[i].correct_answer;
+      incorrect_answers[i] = results[i].incorrect_answers;
+    }
+    console.log('finishquizontent');
+  })
+}
+
+//クイズと選択肢を出力
+function displayQuiz(janre, difficulty, question, type, correct_answer, incorrect_answers) {
+  count ++;
+
+  //問題、ジャンル、難易度を出力
+  let h = document.createElement('h1');
+  h.textContent = '問題' + count;
+  output.appendChild(h);
+
+  let janreContent = document.createElement('p');
+  janreContent.textContent = '[ジャンル]' + janre;
+  output.appendChild(janreContent);
+
+  let difficultyContent = document.createElement('p');
+  difficultyContent.textContent = '[難易度]' + difficulty;
+  output.appendChild(difficultyContent);
+
+  const hr1 = document.createElement('hr');
+  output.appendChild(hr1);
+
+  const questionContent = document.createElement('p');
+  questionContent.textContent = question;
+  output.appendChild(questionContent);
+
+  const hr2 = document.createElement('hr');
+  output.appendChild(hr2);
+
+  const btnDiv = document.createElement('div');
+  output.appendChild(btnDiv);
+
+  //選択肢を出力
+  if( type === 'boolean') {
+    //YesNoクエスチョンのとき
+    const trueBtn = document.createElement('input');
+    trueBtn.type = 'button';
+    trueBtn.value = 'True';
+    trueBtn.classList.add('btn');
+    btnDiv.appendChild(trueBtn);
+
+    const FalseBtn = document.createElement('input');
+    FalseBtn.type = 'button';
+    FalseBtn.value = 'False';
+    FalseBtn.classList.add('btn');
+    btnDiv.appendChild(FalseBtn);
+
+    //ボタン押下された際の処理を記載
+    trueBtn.addEventListener('click', function() {
+      output.textContent = '';
+      selectAnswer = 'True';
+      quizContent();
+    })
+    FalseBtn.addEventListener('click', function() {
+      output.textContent = '';
+      selectAnswer = 'False';
+      quizContent();
+    })
+    //正解を選択した場合にカウントする
+    if (selectAnswer = correct_answer) {
+      correctAnswerCount ++;
+    }
+
+  } else {
+    //４択のとき
+    let correctQuestionNumber = Math.random() * 3;
+    for (let i = 0; i < 3; i++){
+      if (correctQuestionNumber < i) {
+        const answerBtn =document.createElement('input');
+        answerBtn.type = 'button';
+        answerBtn.classList.add('btn');
+        answerBtn.value = correct_answer;
+        btnDiv.appendChild(answerBtn)
+
+        //ボタン押下された際の処理を記載
+        answerBtn.addEventListener('click', function() {
+        output.textContent = '';
+        correctAnswerCount ++;
+        quizContent();
+        })
+      }
+      const answerBtn =document.createElement('input');
+      answerBtn.type = 'button';
+      // let arrayIncorrect_answers = incorrect_answers;
+      // console.log(incorrect_answers);
+      // answerBtn.value = arrayIncorrect_answers[i];
+      answerBtn.value = incorrect_answers[i];
+      answerBtn.classList.add('btn');
+      btnDiv.appendChild(answerBtn);
+
+      //ボタン押下された際の処理を記載
+      answerBtn.addEventListener('click', function() {
+        output.textContent = '';
+        quizContent();
+      })
+    }
+  }
+  // count++;
+}
+
+//クイズ結果を出力
+function displayResult() {
+  const h = document.createElement('h1');
+  h.textContent = 'あなたの正答数は' + correctAnswerCount + 'です！！';
+  output.appendChild(h);
+
+  const hr1 = document.createElement('hr');
+  output.appendChild(hr1);
+
+  const p = document.createElement('p');
+  p.textContent = '再度チャレンジしたい場合は以下をクリック！！';
+  output.appendChild(p);
+
+  const hr2 = document.createElement('hr');
+  output.appendChild(hr2);
+
+  const clickbtn = document.createElement('input');
+  clickbtn.type = 'button';
+  clickbtn.value = 'ホームに戻る';
+  output.appendChild(clickbtn);
+
+  clickbtn.addEventListener('click', function() {
+    //トップページに移動、初期化
+    output.textContent = '';
+    count = 0;
+    correctAnswerCount = 0;
+    displayTopPage();
+  } )
+
+}

--- a/assets/JS04.js
+++ b/assets/JS04.js
@@ -4,13 +4,7 @@ const output = document.getElementById('output');
 let count = 0;
 let correctAnswerCount = 0;
 let selectAnswer = '';
-let janre = [];
-let difficulty = [];
-let question = [];
-let type = [];
-let correct_answer = [];
-let incorrect_answers = [];
-
+let quiz = 0;
 
 //最初のページを作成
 function displayTopPage() {
@@ -35,26 +29,74 @@ function displayTopPage() {
 
   clickbtn.addEventListener('click', function() {
     output.textContent = '';
-    function finishQuizContent() {
-      return new Promise((resolve) => {
-        resolve(quizContent);
-      })
-    }
+    // function finishQuizContent() {
+    //   return new Promise((resolve) => {
+    //     resolve(quizContent);
+    //   })
+    // }
 
-    function finishDisplayStayPage() {
-      return new Promise((resolve) => {
-        resolve(displayStayPage);
+    // function finishDisplayStayPage() {
+    //   return new Promise((resolve) => {
+    //     resolve(displayStayPage);
+    //   })
+    // }
+    // //「待機中」ページを出力し、fetchでのデータ読み込みが終了したらクイズ画面を出力
+    // Promise.all([
+    //   finishDisplayStayPage(),
+    //   finishQuizContent()
+    // ]).then(function(){
+    //   output.textContent = '';
+    //   console.log('add');
+    //   add();
+    // })
+
+    // const finishQuizContent = async function() {
+    //   quizContent();
+    // }
+
+    // const finishDisplayStayPage = async function() {
+    //   displayStayPage();
+    // }
+
+    // const displayQuizPage = async function() {
+    //   output.textContent = '';
+    //   console.log('add');
+    //   add();
+    // }
+
+    // const processAll = async function() {
+    //   await finishQuizContent();
+    //   await finishDisplayStayPage();
+    //   await displayQuizPage();
+    // }
+
+    // processAll();
+
+    const finishQuizContent = new Promise((resolve, reject) => {
+        quiz = fetch('https://opentdb.com/api.php?amount=10').then(function  (response) {
+          return response.json();
+        }).then(function(json) {
+            return json.results;
+        })
+        // console.log(quizContent);
+        console.log(quiz[1].difficulty);
+
+        resolve();
       })
-    }
-    //「待機中」ページを出力し、fetchでのデータ読み込みが終了したらクイズ画面を出力
-    Promise.all([
-      finishDisplayStayPage(),
-      finishQuizContent()
-    ]).then(function(){
-      output.textContent = '';
-      console.log('add');
-      add();
+
+    const finishDisplayStayPage = new Promise((resolve, reject) => {
+        displayStayPage();
+        resolve();
+      })
+
+    const displayQuizPage = new Promise((resolve, reject) => {
+        output.textContent = '';
+        console.log('add');
+        add();
+        resolve();
     })
+
+     finishQuizContent.then(finishDisplayStayPage).then(displayQuizPage);
   } )
 
 }
@@ -62,8 +104,7 @@ displayTopPage();
 
 function add() {
   if (count < 10) {
-    displayQuiz(janre[count], difficulty[count], question[count], type[count], correct_answer[count], incorrect_answers[count]);
-    console.log(incorrect_answers[count]);
+    displayQuiz();
     }else{
       displayResult();
     }
@@ -87,26 +128,27 @@ function displayStayPage() {
 }
 
 //クイズを取り出す
-function quizContent() {
-  fetch('https://opentdb.com/api.php?amount=10').then(function  (response) {
-    return response.json();
-  }).then(function(json) {
-      return json.results;
-  }).then(function(results) {
-    for (let i = 0; i< results.length; i++) {
-      janre[i] = results[i].category;
-      difficulty[i] = results[i].difficulty;
-      question[i] = results[i].question;
-      type[i] = results[i].type;
-      correct_answer[i] = results[i].correct_answer;
-      incorrect_answers[i] = results[i].incorrect_answers;
-    }
-    console.log('finishquizontent');
-  })
-}
+// function quizContent() {
+
+//   fetch('https://opentdb.com/api.php?amount=10').then(function  (response) {
+//     return response.json();
+//   }).then(function(json) {
+//       return json.results;
+//   }).then(function(results) {
+//     for (let i = 0; i< results.length; i++) {
+//       janre[i] = results[i].category;
+//       difficulty[i] = results[i].difficulty;
+//       question[i] = results[i].question;
+//       type[i] = results[i].type;
+//       correct_answer[i] = results[i].correct_answer;
+//       incorrect_answers[i] = results[i].incorrect_answers;
+//     }
+//     console.log('finishquizontent');
+//   })
+// }
 
 //クイズと選択肢を出力
-function displayQuiz(janre, difficulty, question, type, correct_answer, incorrect_answers) {
+function displayQuiz() {
   count ++;
 
   //問題、ジャンル、難易度を出力
@@ -115,18 +157,18 @@ function displayQuiz(janre, difficulty, question, type, correct_answer, incorrec
   output.appendChild(h);
 
   let janreContent = document.createElement('p');
-  janreContent.textContent = '[ジャンル]' + janre;
+  janreContent.textContent = '[ジャンル]' + quiz[count].janre;
   output.appendChild(janreContent);
 
   let difficultyContent = document.createElement('p');
-  difficultyContent.textContent = '[難易度]' + difficulty;
+  difficultyContent.textContent = '[難易度]' + quiz[count].difficulty;
   output.appendChild(difficultyContent);
 
   const hr1 = document.createElement('hr');
   output.appendChild(hr1);
 
   const questionContent = document.createElement('p');
-  questionContent.textContent = question;
+  questionContent.textContent = quiz[count].question;
   output.appendChild(questionContent);
 
   const hr2 = document.createElement('hr');
@@ -136,7 +178,7 @@ function displayQuiz(janre, difficulty, question, type, correct_answer, incorrec
   output.appendChild(btnDiv);
 
   //選択肢を出力
-  if( type === 'boolean') {
+  if( quiz[count].type === 'boolean') {
     //YesNoクエスチョンのとき
     const trueBtn = document.createElement('input');
     trueBtn.type = 'button';
@@ -162,7 +204,7 @@ function displayQuiz(janre, difficulty, question, type, correct_answer, incorrec
       quizContent();
     })
     //正解を選択した場合にカウントする
-    if (selectAnswer = correct_answer) {
+    if (selectAnswer = quiz[count].correct_answer) {
       correctAnswerCount ++;
     }
 
@@ -174,7 +216,7 @@ function displayQuiz(janre, difficulty, question, type, correct_answer, incorrec
         const answerBtn =document.createElement('input');
         answerBtn.type = 'button';
         answerBtn.classList.add('btn');
-        answerBtn.value = correct_answer;
+        answerBtn.value = quiz[count].correct_answer;
         btnDiv.appendChild(answerBtn)
 
         //ボタン押下された際の処理を記載
@@ -189,7 +231,7 @@ function displayQuiz(janre, difficulty, question, type, correct_answer, incorrec
       // let arrayIncorrect_answers = incorrect_answers;
       // console.log(incorrect_answers);
       // answerBtn.value = arrayIncorrect_answers[i];
-      answerBtn.value = incorrect_answers[i];
+      answerBtn.value = quiz[count].incorrect_answers[i];
       answerBtn.classList.add('btn');
       btnDiv.appendChild(answerBtn);
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JS04</title>
+  <link rel="stylesheet" href="assets/JS04.css">
+</head>
+<body>
+  <div id="output">
+
+  </div>
+  <script src="assets/JS04.js"></script>
+</body>
+</html>


### PR DESCRIPTION
①クイズの取得方法を変更
   【修正前】クイズの項目ごとの空の配列を作りapiのクイズ項目ごとのデータを代入する形
　【修正後】入手したデータを変数quizに格納して、変数[number].クイズデータ項目（キー）を表示させる形
②「開始」ボタンクリック時の非同期処理の記載を変更（Promise.all⇒then）